### PR TITLE
Logical disk new counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # WMI exporter
-Moshe Anconina
+
 [![Build status](https://ci.appveyor.com/api/projects/status/ljwan71as6pf2joe?svg=true)](https://ci.appveyor.com/project/martinlindhe/wmi-exporter)
 
 Prometheus exporter for Windows machines, using the WMI (Windows Management Instrumentation).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # WMI exporter
-
+Moshe Anconina
 [![Build status](https://ci.appveyor.com/api/projects/status/ljwan71as6pf2joe?svg=true)](https://ci.appveyor.com/project/martinlindhe/wmi-exporter)
 
 Prometheus exporter for Windows machines, using the WMI (Windows Management Instrumentation).

--- a/collector/logical_disk.go
+++ b/collector/logical_disk.go
@@ -29,17 +29,20 @@ var (
 
 // A LogicalDiskCollector is a Prometheus collector for WMI Win32_PerfRawData_PerfDisk_LogicalDisk metrics
 type LogicalDiskCollector struct {
-	RequestsQueued  *prometheus.Desc
-	ReadBytesTotal  *prometheus.Desc
-	ReadsTotal      *prometheus.Desc
-	WriteBytesTotal *prometheus.Desc
-	WritesTotal     *prometheus.Desc
-	ReadTime        *prometheus.Desc
-	WriteTime       *prometheus.Desc
-	TotalSpace      *prometheus.Desc
-	FreeSpace       *prometheus.Desc
-	IdleTime        *prometheus.Desc
-	SplitIOs        *prometheus.Desc
+	RequestsQueued   *prometheus.Desc
+	ReadBytesTotal   *prometheus.Desc
+	ReadsTotal       *prometheus.Desc
+	WriteBytesTotal  *prometheus.Desc
+	WritesTotal      *prometheus.Desc
+	ReadTime         *prometheus.Desc
+	WriteTime        *prometheus.Desc
+	TotalSpace       *prometheus.Desc
+	FreeSpace        *prometheus.Desc
+	IdleTime         *prometheus.Desc
+	SplitIOs         *prometheus.Desc
+	ReadLatency      *prometheus.Desc
+	WriteLatency     *prometheus.Desc
+	ReadWriteLatency *prometheus.Desc
 
 	volumeWhitelistPattern *regexp.Regexp
 	volumeBlacklistPattern *regexp.Regexp
@@ -127,6 +130,27 @@ func NewLogicalDiskCollector() (Collector, error) {
 			nil,
 		),
 
+		ReadLatency: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "read_latency"),
+			"Shows the average time, in seconds, of a read operation from the disk (LogicalDisk.AvgDiskSecPerRead)",
+			[]string{"volume"},
+			nil,
+		),
+
+		WriteLatency: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "write_latency"),
+			"Shows the average time, in seconds, of a write operation to the disk (LogicalDisk.AvgDiskSecPerWrite)",
+			[]string{"volume"},
+			nil,
+		),
+
+		ReadWriteLatency: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "read_write_latency"),
+			"Shows the time, in seconds, of the average disk transfer (LogicalDisk.AvgDiskSecPerTransfer)",
+			[]string{"volume"},
+			nil,
+		),
+
 		volumeWhitelistPattern: regexp.MustCompile(fmt.Sprintf("^(?:%s)$", *volumeWhitelist)),
 		volumeBlacklistPattern: regexp.MustCompile(fmt.Sprintf("^(?:%s)$", *volumeBlacklist)),
 	}, nil
@@ -158,6 +182,9 @@ type Win32_PerfRawData_PerfDisk_LogicalDisk struct {
 	PercentFreeSpace_Base  uint32
 	PercentIdleTime        uint64
 	SplitIOPerSec          uint32
+	AvgDiskSecPerRead      uint64
+	AvgDiskSecPerWrite     uint64
+	AvgDiskSecPerTransfer  uint64
 }
 
 func (c *LogicalDiskCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
@@ -248,6 +275,27 @@ func (c *LogicalDiskCollector) collect(ch chan<- prometheus.Metric) (*prometheus
 			c.SplitIOs,
 			prometheus.CounterValue,
 			float64(volume.SplitIOPerSec),
+			volume.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.ReadLatency,
+			prometheus.CounterValue,
+			float64(volume.AvgDiskSecPerRead),
+			volume.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.WriteLatency,
+			prometheus.CounterValue,
+			float64(volume.AvgDiskSecPerWrite),
+			volume.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.ReadWriteLatency,
+			prometheus.CounterValue,
+			float64(volume.AvgDiskSecPerTransfer),
 			volume.Name,
 		)
 	}


### PR DESCRIPTION
Hello,

I have implemented new logical disk counters that represents disk operations latency according the following article : https://blogs.technet.microsoft.com/askcore/2012/02/07/measuring-disk-latency-with-windows-performance-monitor-perfmon/

> What counters in Windows Performance Monitor show the physical disk latency?
> “Physical disk performance object -> Avg. Disk sec/Read counter” – Shows the average read latency.
> “Physical disk performance object -> Avg. Disk sec/Write counter” – Shows the average write latency.
> “Physical disk performance object -> Avg. Disk sec/Transfer counter” – Shows the combined averages for both read and writes.

Thanks
Moshe